### PR TITLE
create tmp _static folder first

### DIFF
--- a/launchers/jb-build.sh
+++ b/launchers/jb-build.sh
@@ -26,6 +26,7 @@ fi
 
 # make directories
 mkdir -p ${JB_BUILD_CACHE_DIR}
+mkdir -p "${JB_SOURCE_TMP_DIR}/_static/"
 
 # configure environment
 export HOME=${JB_BUILD_CACHE_DIR}


### PR DESCRIPTION
Otherwise, the following error is produced:

```
<== Entrypoint
Directory '/out/html' found. Will build HTML.
Directory '/out/pdf' not found. Skipping PDF compilation.
cp: target '/tmp/src/_static/' is not a directory
```