### PR TITLE
Fix for pdf build

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -15,7 +15,6 @@ beautifulsoup4==4.8.2
 # needed only for PDF building
 pyppeteer==1.0.2
 
-
 # used to fetch the books list from the online library
 requests==2.28.1
 

--- a/packages/book_image_optimizer/main.py
+++ b/packages/book_image_optimizer/main.py
@@ -285,6 +285,11 @@ if __name__ == "__main__":
     media["images"].update({
         k: dataclasses.asdict(v) for k, v in images.items()
     })
+
+    # create parent path if non-existing
+    if not os.path.exists(media_fpath):
+        Path(html_path).mkdir(parents=True, exist_ok=True)
+
     # write map to disk
     with open(media_fpath, "wt") as fout:
         json.dump(media, fout, sort_keys=True, indent=4)


### PR DESCRIPTION
After fix, the pdf was built locally:
```
INFO:dts:                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                            
=========================================================================================                                                                                                                                                                                                   
|                                                                                       |                                                                                                                                                                                                   
|    HTML artifacts: /home/sjhu/Repositories/duckietown/book-devmanual-software/html    |
|                                                                                       |
=========================================================================================

INFO:dts:

===============================================================================================
|                                                                                             |
|    PDF artifact: /home/sjhu/Repositories/duckietown/book-devmanual-software/pdf/book.pdf    |
|                                                                                             |
===============================================================================================

```
![image](https://github.com/duckietown/dt-jupyter-book/assets/10885835/f08a33cc-a120-432c-8b97-e49e03e80cef)


Before this fix, can reproduce the problem on CI:
```
dts :  Traceback (most recent call last):
    :    File "/home/sjhu/.local/lib/python3.8/site-packages/dt_shell/main.py", line 41, in cli_main
    :      cli_main_()
    :    File "/home/sjhu/.local/lib/python3.8/site-packages/dt_shell/main.py", line 183, in cli_main_
    :      shell.onecmd(cmdline)
    :    File "/usr/lib/python3.8/cmd.py", line 217, in onecmd
    :      return func(arg)
    :    File "/home/sjhu/.local/lib/python3.8/site-packages/dt_shell/cli.py", line 288, in <lambda>
    :      do_command_lam = lambda s, w: do_command(klass, s, w)
    :    File "/home/sjhu/.local/lib/python3.8/site-packages/dt_shell/dt_command_abs.py", line 41, in do_command
    :      cls.commands[word].do_command(cls.commands[word], shell, " ".join(parts[1:]))
    :    File "/home/sjhu/.local/lib/python3.8/site-packages/dt_shell/dt_command_abs.py", line 48, in do_command
    :      cls.command(shell, args)
    :    File "/home/sjhu/.dt-shell/commands-multi/daffy/docs/build/command.py", line 80, in command
    :      return build_v2(shell, args)
    :    File "/home/sjhu/.dt-shell/commands-multi/daffy/docs/build/command.py", line 325, in build_v2
    :      consume_container_logs(logs)
    :    File "/home/sjhu/.dt-shell/commands-multi/daffy/docs/build/command.py", line 299, in consume_container_logs
    :      for (stream, line) in _logs:
    :    File "/home/sjhu/.local/lib/python3.8/site-packages/dockertown/utils.py", line 313, in stream_stdout_and_stderr
    :      raise DockerException(full_cmd, exit_code, stderr=full_stderr)
    :  dockertown.exceptions.DockerException: The docker command executed was `/usr/bin/docker container run --env BOOK_BRANCH_NAME=daffy-staging --env LIBRARY_HOSTNAME=staging-docs.duckietown.com --env LIBRARY_DISTRO=daffy --env DEBUG=0 --env PRODUCTION_BUILD=0 --name docs-build-book-devmanual-software --rm --user 1001:1001 --volume /home/sjhu/Repositories/duckietown/book-devmanual-software:/book:ro --volume /home/sjhu/Repositories/duckietown/book-devmanual-software/html:/out/html:rw --volume /home/sjhu/Repositories/duckietown/book-devmanual-software/pdf:/out/pdf:rw docker.io/duckietown/book-devmanual-software:daffy-staging-env-amd64`.
    :  It returned with code 1
    :  The content of stdout can be found above the stacktrace (it wasn't captured).
    :  The content of stderr is 'find: ‘/tmp/jb/_build/html/_images’: No such file or directory
    :  WARNING:ImagesOptimizer:Invalid image found at: -
    :  Traceback (most recent call last):
    :    File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    :      return _run_code(code, main_globals, None,
    :    File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    :      exec(code, run_globals)
    :    File "/code/dt-jupyter-book/packages/book_image_optimizer/main.py", line 289, in <module>
    :      with open(media_fpath, "wt") as fout:
    :  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/jb/_build/html/media.json'
    :  '
```